### PR TITLE
添加主CMake文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 
 # ignore idea specific workspace settings
 .idea
+
+# ignore cmake outputs
+cmake-*
+build
+out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.24)
+project(decaf_compiler VERSION 0.0.1)
+set(CMAKE_CXX_STANDARD 23)


### PR DESCRIPTION
尽快合并到main分支上，因为主分支编译以及自动单元测试的已经加上去了。