### PR TITLE
添加cmake文件预设

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Build All Targets
         run: cmake --build build
       
-      - name: Test Current Working Directory
-        run: pwd
-      
-      - name: Test Current Working Directory(with work-directory)
-        run: pwd
+      - name: Run Unit Tests
+        run: ctest
         working-directory: ./build

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_and_unit_test:
     runs-on: ubuntu-latest
     # using latest development file
     container: 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure CMake
-        run: cmake -S . -B build
+        run: cmake --preset "debug" -S . -B build
 
       - name: Build All Targets
         run: cmake --build build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+    "version": 5,
+    "configurePresets": [
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "debug"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "debug"
+        }
+    ]
+}


### PR DESCRIPTION
使用文件预设来配合VCPKG进行C++的包管理，这样能简化命令行。