### PR TITLE
添加依赖图生成目标

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,3 +25,9 @@ include(CTest)
 include(Catch)
 
 add_subdirectory(tests)
+
+add_custom_target(graphviz
+        COMMAND ${CMAKE_COMMAND} "--graphviz=dependency.dot" .
+        COMMAND dot -Tpng dependency.dot -o dependency.png
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        )


### PR DESCRIPTION
在cmake中添加了依赖图生成的目标，可以通过手动构建`graphviz`目标获得依赖图