### PR TITLE
实现数学表达式AST和Parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_custom_target(run_flex_bison
 include_directories(${CMAKE_BINARY_DIR})
 
 add_subdirectory(token)
+add_subdirectory(ast)
 add_subdirectory(scanner)
 
 find_package(Catch2 3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,12 @@ add_custom_target(run_flex_bison
         )
 
 include_directories(${CMAKE_BINARY_DIR})
+add_subdirectory(basic)
 
 add_subdirectory(token)
 add_subdirectory(ast)
 add_subdirectory(scanner)
+add_subdirectory(parser)
 
 find_package(Catch2 3 REQUIRED)
 include(CTest)

--- a/apis/serializable.h
+++ b/apis/serializable.h
@@ -5,7 +5,9 @@
 namespace decaf {
 
 class serializable {
+public:
     virtual boost::json::value to_json() = 0;
+    virtual ~serializable() = default;
 };
 
 } // namespace decaf

--- a/ast/CMakeLists.txt
+++ b/ast/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(ast expr.cpp)
+target_include_directories(ast PUBLIC .)
+target_link_libraries(ast PUBLIC token)

--- a/ast/CMakeLists.txt
+++ b/ast/CMakeLists.txt
@@ -1,3 +1,2 @@
 add_library(ast expr.cpp)
 target_include_directories(ast PUBLIC .)
-target_link_libraries(ast PUBLIC token)

--- a/ast/CMakeLists.txt
+++ b/ast/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_library(ast expr.cpp)
 target_include_directories(ast PUBLIC .)
+target_link_libraries(ast PUBLIC parser_impl_basic)

--- a/ast/expr.cpp
+++ b/ast/expr.cpp
@@ -1,0 +1,1 @@
+#include "expr.h"

--- a/ast/expr.cpp
+++ b/ast/expr.cpp
@@ -1,20 +1,20 @@
 #include "expr.h"
 
-bool decaf::ast::ArithmeticBinary::equals(std::shared_ptr<Expr> ptr) {
-    auto arith = std::dynamic_pointer_cast<ArithmeticBinary>(ptr);
+bool decaf::ast::ArithmeticBinary::equals(Expr* ptr) {
+    auto arith = dynamic_cast<ArithmeticBinary*>(ptr);
 
     // Not the same type
-    if (!arith) {
+    if (arith == nullptr) {
         return false;
     }
 
     return this->op == arith->op && this->left->equals(arith->left) && this->right->equals(arith->right);
 }
 
-bool decaf::ast::IntConstant::equals(std::shared_ptr<Expr> ptr) {
-    auto val = std::dynamic_pointer_cast<IntConstant>(ptr);
+bool decaf::ast::IntConstant::equals(Expr* ptr) {
+    auto val = dynamic_cast<IntConstant*>(ptr);
 
-    if (!val) {
+    if (val == nullptr) {
         return false;
     }
 

--- a/ast/expr.cpp
+++ b/ast/expr.cpp
@@ -1,1 +1,22 @@
 #include "expr.h"
+
+bool decaf::ast::ArithmeticBinary::equals(std::shared_ptr<Expr> ptr) {
+    auto arith = std::dynamic_pointer_cast<ArithmeticBinary>(ptr);
+
+    // Not the same type
+    if (!arith) {
+        return false;
+    }
+
+    return this->op == arith->op && this->left->equals(arith->left) && this->right->equals(arith->right);
+}
+
+bool decaf::ast::IntConstant::equals(std::shared_ptr<Expr> ptr) {
+    auto val = std::dynamic_pointer_cast<IntConstant>(ptr);
+
+    if (!val) {
+        return false;
+    }
+
+    return this->value == val->value;
+}

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -27,7 +27,7 @@ struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBin
     std::shared_ptr<Expr> right;
 
     std::any accept(ExprVisitor& visitor) override {
-        visitor.visitArithmeticBinary(shared_from_this());
+        return visitor.visitArithmeticBinary(shared_from_this());
     }
 };
 
@@ -35,7 +35,7 @@ struct IntConstant: Expr, public std::enable_shared_from_this<IntConstant> {
     int value;
 
     std::any accept(ExprVisitor& visitor) override {
-        visitor.visitIntConstant(shared_from_this());
+        return visitor.visitIntConstant(shared_from_this());
     }
 };
 } // namespace decaf::ast

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "token.h"
 #include <any>
 #include <memory>
 
@@ -23,7 +22,13 @@ struct Expr {
 
 struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBinary> {
     std::shared_ptr<Expr> left;
-    decaf::token op;
+    enum class Operation {
+        PLUS,
+        MINUS,
+        MULTIPLY,
+        DIVIDE
+    };
+    Operation op;
     std::shared_ptr<Expr> right;
 
     std::any accept(ExprVisitor& visitor) override {

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -31,6 +31,13 @@ struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBin
     Operation op;
     std::shared_ptr<Expr> right;
 
+    ArithmeticBinary(std::shared_ptr<Expr> left,
+                     Operation op,
+                     std::shared_ptr<Expr> right):
+        left{std::move(left)},
+        op{op}, right{std::move(right)} {
+    }
+
     std::any accept(ExprVisitor& visitor) override {
         return visitor.visitArithmeticBinary(shared_from_this());
     }

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -16,6 +16,7 @@ namespace decaf::ast {
 struct Expr {
     virtual std::any accept(ExprVisitor&) = 0;
     virtual bool equals(std::shared_ptr<Expr>) = 0;
+    virtual ~Expr() = default;
 };
 
 struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBinary> {

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "token.h"
+#include <any>
+#include <memory>
+
+namespace decaf::ast {
+struct ArithmeticBinary;
+struct IntConstant;
+} // namespace decaf::ast
+
+namespace decaf {
+struct ExprVisitor {
+    virtual std::any visitArithmeticBinary(std::shared_ptr<ast::ArithmeticBinary>) = 0;
+    virtual std::any visitIntConstant(std::shared_ptr<ast::IntConstant>) = 0;
+};
+} // namespace decaf
+
+namespace decaf::ast {
+struct Expr {
+    virtual std::any accept(ExprVisitor&) = 0;
+};
+
+struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBinary> {
+    std::shared_ptr<Expr> left;
+    decaf::token op;
+    std::shared_ptr<Expr> right;
+
+    std::any accept(ExprVisitor& visitor) override {
+        visitor.visitArithmeticBinary(shared_from_this());
+    }
+};
+
+struct IntConstant: Expr, public std::enable_shared_from_this<IntConstant> {
+    int value;
+
+    std::any accept(ExprVisitor& visitor) override {
+        visitor.visitIntConstant(shared_from_this());
+    }
+};
+} // namespace decaf::ast

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -3,6 +3,7 @@
 #include "ast_basic.h"
 #include <any>
 #include <memory>
+#include <utility>
 
 namespace decaf {
 struct ExprVisitor {
@@ -14,6 +15,7 @@ struct ExprVisitor {
 namespace decaf::ast {
 struct Expr {
     virtual std::any accept(ExprVisitor&) = 0;
+    virtual bool equals(std::shared_ptr<Expr>) = 0;
 };
 
 struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBinary> {
@@ -37,6 +39,7 @@ struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBin
     std::any accept(ExprVisitor& visitor) override {
         return visitor.visitArithmeticBinary(shared_from_this());
     }
+    bool equals(std::shared_ptr<Expr> ptr) override;
 };
 
 struct IntConstant: Expr, public std::enable_shared_from_this<IntConstant> {
@@ -45,5 +48,6 @@ struct IntConstant: Expr, public std::enable_shared_from_this<IntConstant> {
     std::any accept(ExprVisitor& visitor) override {
         return visitor.visitIntConstant(shared_from_this());
     }
+    bool equals(std::shared_ptr<Expr> ptr) override;
 };
 } // namespace decaf::ast

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -46,6 +46,10 @@ struct ArithmeticBinary: Expr, public std::enable_shared_from_this<ArithmeticBin
 struct IntConstant: Expr, public std::enable_shared_from_this<IntConstant> {
     int value;
 
+    explicit IntConstant(int val):
+        value{val} {
+    }
+
     std::any accept(ExprVisitor& visitor) override {
         return visitor.visitIntConstant(shared_from_this());
     }

--- a/ast/expr.h
+++ b/ast/expr.h
@@ -1,12 +1,8 @@
 #pragma once
 
+#include "ast_basic.h"
 #include <any>
 #include <memory>
-
-namespace decaf::ast {
-struct ArithmeticBinary;
-struct IntConstant;
-} // namespace decaf::ast
 
 namespace decaf {
 struct ExprVisitor {

--- a/basic/CMakeLists.txt
+++ b/basic/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(parser_impl_basic INTERFACE
+        ast_basic.h parser_basic.h
+        )
+target_include_directories(parser_impl_basic INTERFACE .)

--- a/basic/ast_basic.h
+++ b/basic/ast_basic.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace decaf::ast {
+struct Expr;
+struct ArithmeticBinary;
+struct IntConstant;
+} // namespace decaf::ast

--- a/basic/parser_basic.h
+++ b/basic/parser_basic.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace decaf {
+class Parser;
+}

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,3 +1,6 @@
-add_library(parser parser.cpp)
+add_library(parser parser.cpp
+        ${BISON_DecafParser_OUTPUTS}
+        )
 add_dependencies(parser run_flex_bison)
 target_link_libraries(parser PUBLIC ast scanner)
+target_include_directories(parser PUBLIC .)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(parser parser.cpp)
+add_dependencies(parser run_flex_bison)
+target_link_libraries(parser PUBLIC ast scanner)

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -1,0 +1,1 @@
+#include "parser.h"

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -1,1 +1,27 @@
 #include "parser.h"
+#include "token.h"
+#include <string>
+
+int yylex(yy::parser::value_type* yylval, decaf::Parser& driver) {
+    using decaf::token_type;
+    auto& next_token = driver.next_token;
+    auto& token_stream = driver.token_stream;
+    if (next_token == token_stream.end()) {
+        return token_type::YYEOF;
+    }
+
+    // Must use big switch-case here, because no
+    // polymorphism is available for token type.
+    switch (next_token->type) {
+        case token_type::INTEGER:
+        case token_type::HEX_INTEGER:
+            yylval->emplace<int>(std::stoi(next_token->lexeme));
+            break;
+        default:
+            // No semantic value for other types
+            // leave yylval unchanged
+            break;
+    }
+
+    return (next_token++)->type;
+}

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -25,3 +25,13 @@ int yylex(yy::parser::value_type* yylval, decaf::Parser& driver) {
 
     return (next_token++)->type;
 }
+
+
+void decaf::Parser::parse() {
+    // TODO: handle errors, for now ignore return value
+    parser_impl.parse();
+}
+
+decaf::Parser::ast_ptr decaf::Parser::get_ast() {
+    return ast_root;
+}

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -17,15 +17,15 @@ public:
     void parse();
     ast_ptr get_ast();
 
-    explicit Parser(decaf::Scanner::token_stream _token_stream):
+    explicit Parser(decaf::token_stream _token_stream):
         token_stream{std::move(_token_stream)},
         next_token{token_stream.begin()} {
     }
 
 private:
     yy::parser parser_impl{*this};
-    decaf::Scanner::token_stream token_stream;
-    decaf::Scanner::token_stream::iterator next_token;
+    decaf::token_stream token_stream;
+    decaf::token_stream::iterator next_token;
     ast_ptr ast_root{nullptr};
 };
 } // namespace decaf

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -16,8 +16,8 @@ public:
     void parse();
     ast_ptr get_ast();
 
-    explicit Parser(decaf::Scanner::token_stream token_stream):
-        token_stream{std::move(token_stream)},
+    explicit Parser(decaf::Scanner::token_stream _token_stream):
+        token_stream{std::move(_token_stream)},
         next_token{token_stream.begin()} {
     }
 

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -13,7 +13,7 @@ class Parser {
     friend class yy::parser;
 
 public:
-    using ast_ptr = std::shared_ptr<decaf::ast::Expr>;
+    using ast_ptr = decaf::ast::Expr*;
     void parse();
     ast_ptr get_ast();
 
@@ -26,6 +26,6 @@ private:
     yy::parser parser_impl{*this};
     decaf::Scanner::token_stream token_stream;
     decaf::Scanner::token_stream::iterator next_token;
-    ast_ptr ast_root{};
+    ast_ptr ast_root{nullptr};
 };
 } // namespace decaf

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -5,8 +5,12 @@
 #include "scanner.h"
 #include <memory>
 
+int yylex(yy::parser::value_type* yylval, decaf::Parser& driver);
+
 namespace decaf {
 class Parser {
+    friend int ::yylex(yy::parser::value_type* yylval, decaf::Parser& driver);
+
 public:
     using ast_ptr = std::shared_ptr<decaf::ast::Expr>;
     void parse();
@@ -15,8 +19,6 @@ public:
 private:
     yy::parser parser_impl;
     decaf::Scanner::token_stream token_stream;
-    decaf::Scanner::token_stream::iterator current_token;
+    decaf::Scanner::token_stream::iterator next_token;
 };
 } // namespace decaf
-
-int yylex(yy::parser::value_type* yylval);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "expr.h"
+#include "parser_impl.h"
+#include "scanner.h"
+#include <memory>
+
+namespace decaf {
+class Parser {
+public:
+    using ast_ptr = std::shared_ptr<decaf::ast::Expr>;
+    void parse();
+    ast_ptr get_ast();
+
+private:
+    yy::parser parser_impl;
+    decaf::Scanner::token_stream token_stream;
+    decaf::Scanner::token_stream::iterator current_token;
+};
+} // namespace decaf
+
+int yylex(yy::parser::value_type* yylval);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -10,6 +10,7 @@ int yylex(yy::parser::value_type* yylval, decaf::Parser& driver);
 namespace decaf {
 class Parser {
     friend int ::yylex(yy::parser::value_type* yylval, decaf::Parser& driver);
+    friend class yy::parser;
 
 public:
     using ast_ptr = std::shared_ptr<decaf::ast::Expr>;

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -16,9 +16,15 @@ public:
     void parse();
     ast_ptr get_ast();
 
+    explicit Parser(decaf::Scanner::token_stream token_stream):
+        token_stream{std::move(token_stream)},
+        next_token{token_stream.begin()} {
+    }
+
 private:
-    yy::parser parser_impl;
+    yy::parser parser_impl{*this};
     decaf::Scanner::token_stream token_stream;
     decaf::Scanner::token_stream::iterator next_token;
+    ast_ptr ast_root{};
 };
 } // namespace decaf

--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -19,10 +19,6 @@
     using namespace decaf::ast;
 }
 
-%code {
-    int yylex(yy::parser::value_type* yylval);
-}
-
 %nterm <std::shared_ptr<decaf::ast::Expr>> expr
 %nterm <std::shared_ptr<decaf::ast::IntConstant>> intConstant
 

--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -19,8 +19,8 @@
     using namespace decaf::ast;
 }
 
-%nterm <std::shared_ptr<decaf::ast::Expr>> arithmeticBinaryExpr
-%nterm <std::shared_ptr<decaf::ast::IntConstant>> intConstant
+%nterm <decaf::ast::Expr*> arithmeticBinaryExpr
+%nterm <decaf::ast::IntConstant*> intConstant
 
 %token <int> INTEGER
 %token <int> HEX_INTEGER
@@ -46,28 +46,28 @@ arithmeticBinaryExpr:
         $$ = $1;
     }
     | arithmeticBinaryExpr PLUS arithmeticBinaryExpr {
-        $$ = make_shared<ArithmeticBinary> (
+        $$ = new ArithmeticBinary (
             $1,
             ArithmeticBinary::Operation::PLUS,
             $3
         );
     }
     | arithmeticBinaryExpr MINUS arithmeticBinaryExpr {
-        $$ = make_shared<ArithmeticBinary> (
+        $$ = new ArithmeticBinary (
             $1,
             ArithmeticBinary::Operation::MINUS,
             $3
         );
     }
     | arithmeticBinaryExpr STAR arithmeticBinaryExpr {
-        $$ = make_shared<ArithmeticBinary> (
+        $$ = new ArithmeticBinary (
             $1,
             ArithmeticBinary::Operation::MULTIPLY,
             $3
         );
     }
     | arithmeticBinaryExpr SLASH arithmeticBinaryExpr {
-        $$ = make_shared<ArithmeticBinary> (
+        $$ = new ArithmeticBinary (
             $1,
             ArithmeticBinary::Operation::DIVIDE,
             $3
@@ -76,10 +76,10 @@ arithmeticBinaryExpr:
 
 intConstant:
     INTEGER {
-        $$ = make_shared<IntConstant>($1);
+        $$ = new IntConstant($1);
     } |
     HEX_INTEGER {
-        $$ = make_shared<IntConstant>($1);
+        $$ = new IntConstant($1);
     }
 
 %%

--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -19,7 +19,7 @@
     using namespace decaf::ast;
 }
 
-%nterm <std::shared_ptr<decaf::ast::Expr>> expr
+%nterm <std::shared_ptr<decaf::ast::Expr>> arithmeticBinaryExpr
 %nterm <std::shared_ptr<decaf::ast::IntConstant>> intConstant
 
 %token <int> INTEGER
@@ -36,40 +36,48 @@
 
 input: 
     %empty
-    | input expr EOL
+    | input arithmeticBinaryExpr EOL
     ;
 
-expr: 
+arithmeticBinaryExpr: 
     intConstant {
         $$ = $1;
     }
-    | expr PLUS expr {
-        $$.left = $1;
-        $$.op = ArithmeticBinary::Operation::PLUS;
-        $$.right = $3;
+    | arithmeticBinaryExpr PLUS arithmeticBinaryExpr {
+        $$ = make_shared<ArithmeticBinary> (
+            $1,
+            ArithmeticBinary::Operation::PLUS,
+            $3
+        );
     }
-    | expr MINUS expr {
-        $$.left = $1;
-        $$.op = ArithmeticBinary::Operation::MINUS;
-        $$.right = $3;
+    | arithmeticBinaryExpr MINUS arithmeticBinaryExpr {
+        $$ = make_shared<ArithmeticBinary> (
+            $1,
+            ArithmeticBinary::Operation::MINUS,
+            $3
+        );
     }
-    | expr STAR expr {
-        $$.left = $1;
-        $$.op = ArithmeticBinary::Operation::MULTIPLY;
-        $$.right = $3;
+    | arithmeticBinaryExpr STAR arithmeticBinaryExpr {
+        $$ = make_shared<ArithmeticBinary> (
+            $1,
+            ArithmeticBinary::Operation::MULTIPLY,
+            $3
+        );
     }
-    | expr SLASH expr {
-        $$.left = $1;
-        $$.op = ArithmeticBinary::Operation::DIVIDE ;
-        $$.right = $3;
+    | arithmeticBinaryExpr SLASH arithmeticBinaryExpr {
+        $$ = make_shared<ArithmeticBinary> (
+            $1,
+            ArithmeticBinary::Operation::DIVIDE,
+            $3
+        );
     }
 
 intConstant:
     INTEGER {
-        $$.value = $1;
+        $$->value = $1;
     } |
     HEX_INTEGER {
-        $$.value = $1;
+        $$->value = $1;
     }
 
 %%

--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -74,10 +74,10 @@ arithmeticBinaryExpr:
 
 intConstant:
     INTEGER {
-        $$->value = $1;
+        $$ = make_shared<IntConstant>($1);
     } |
     HEX_INTEGER {
-        $$->value = $1;
+        $$ = make_shared<IntConstant>($1);
     }
 
 %%

--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -36,7 +36,9 @@
 
 input: 
     %empty
-    | input arithmeticBinaryExpr EOL
+    | input arithmeticBinaryExpr EOL {
+        driver.ast_root = $2;
+    }
     ;
 
 arithmeticBinaryExpr: 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(scanner)
+add_subdirectory(parser)
+
 add_executable(simple_driver simple_driver.cpp)

--- a/tests/parser/CMakeLists.txt
+++ b/tests/parser/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(parser_test parser_test.cpp)
+target_link_libraries(parser_test PRIVATE parser Catch2::Catch2WithMain)
+catch_discover_tests(parser_test)

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -22,6 +22,8 @@ TEST_CASE("parser_main", "[parser]") {
             new ast::IntConstant(34));
 
     REQUIRE(expect->equals(result));
+    delete result;
+    delete expect;
 }
 
 TEST_CASE("parser_plus_left_associative", "[parser]") {
@@ -46,6 +48,8 @@ TEST_CASE("parser_plus_left_associative", "[parser]") {
             new ast::IntConstant(3));
 
     REQUIRE(expect->equals(result));
+    delete result;
+    delete expect;
 }
 
 TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
@@ -70,6 +74,8 @@ TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
                     new ast::IntConstant(3)));
 
     REQUIRE(expect->equals(result));
+    delete result;
+    delete expect;
 }
 
 TEST_CASE("parser_plus_minus", "[parser]") {
@@ -94,6 +100,8 @@ TEST_CASE("parser_plus_minus", "[parser]") {
             new ast::IntConstant(3));
 
     REQUIRE(expect->equals(result));
+    delete result;
+    delete expect;
 }
 
 TEST_CASE("parser_multiply_divide", "[parser]") {
@@ -118,4 +126,6 @@ TEST_CASE("parser_multiply_divide", "[parser]") {
             new ast::IntConstant(3));
 
     REQUIRE(expect->equals(result));
+    delete result;
+    delete expect;
 }

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -71,3 +71,51 @@ TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
 
     REQUIRE(expect->equals(result));
 }
+
+TEST_CASE("parser_plus_minus", "[parser]") {
+    token_stream tokenStream{
+            {token_type ::INTEGER, "1"},
+            {token_type ::PLUS, "+"},
+            {token_type ::INTEGER, "2"},
+            {token_type ::MINUS, "-"},
+            {token_type ::INTEGER, "3"},
+            {token_type ::EOL}};
+
+    decaf::Parser parser{tokenStream};
+    parser.parse();
+
+    auto result = parser.get_ast();
+    auto expect = new ast::ArithmeticBinary(
+            new ast::ArithmeticBinary(
+                    new ast::IntConstant(1),
+                    ast::ArithmeticBinary::Operation::PLUS,
+                    new ast::IntConstant(2)),
+            ast::ArithmeticBinary::Operation::MINUS,
+            new ast::IntConstant(3));
+
+    REQUIRE(expect->equals(result));
+}
+
+TEST_CASE("parser_multiply_divide", "[parser]") {
+    token_stream tokenStream{
+            {token_type ::INTEGER, "1"},
+            {token_type ::STAR, "*"},
+            {token_type ::INTEGER, "2"},
+            {token_type ::SLASH, "/"},
+            {token_type ::INTEGER, "3"},
+            {token_type ::EOL}};
+
+    decaf::Parser parser{tokenStream};
+    parser.parse();
+
+    auto result = parser.get_ast();
+    auto expect = new ast::ArithmeticBinary(
+            new ast::ArithmeticBinary(
+                    new ast::IntConstant(1),
+                    ast::ArithmeticBinary::Operation::MULTIPLY,
+                    new ast::IntConstant(2)),
+            ast::ArithmeticBinary::Operation::DIVIDE,
+            new ast::IntConstant(3));
+
+    REQUIRE(expect->equals(result));
+}

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -1,23 +1,25 @@
 #include "parser.h"
 #include <catch2/catch_test_macros.hpp>
 
-TEST_CASE("parser_main", "[parser]") {
-    using namespace decaf;
+using namespace decaf;
+using token_stream = decaf::Scanner::token_stream;
+using std::make_shared;
 
-    Scanner::token_stream tokenStream{
+TEST_CASE("parser_main", "[parser]") {
+    token_stream tokenStream{
             {token_type ::INTEGER, "12"},
             {token_type ::PLUS, "+"},
             {token_type ::INTEGER, "34"},
             {token_type ::EOL}};
 
-    Parser parser{tokenStream};
+    decaf::Parser parser{tokenStream};
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = std::make_shared<ast::ArithmeticBinary>(
-            std::make_shared<ast::IntConstant>(12),
+    auto expect = make_shared<ast::ArithmeticBinary>(
+            make_shared<ast::IntConstant>(12),
             ast::ArithmeticBinary::Operation::PLUS,
-            std::make_shared<ast::IntConstant>(34));
+            make_shared<ast::IntConstant>(34));
 
     REQUIRE(expect->equals(result));
 }

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -2,7 +2,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 using namespace decaf;
-using token_stream = decaf::Scanner::token_stream;
+using decaf::token_stream;
 using std::make_shared;
 
 TEST_CASE("parser_main", "[parser]") {

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -1,0 +1,23 @@
+#include "parser.h"
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("parser_main", "[parser]") {
+    using namespace decaf;
+
+    Scanner::token_stream tokenStream{
+            {token_type ::INTEGER, "12"},
+            {token_type ::PLUS, "+"},
+            {token_type ::INTEGER, "34"},
+            {token_type ::EOL}};
+
+    Parser parser{tokenStream};
+    parser.parse();
+
+    auto result = parser.get_ast();
+    auto expect = std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(12),
+            ast::ArithmeticBinary::Operation::PLUS,
+            std::make_shared<ast::IntConstant>(34));
+
+    REQUIRE(expect->equals(result));
+}

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -23,3 +23,51 @@ TEST_CASE("parser_main", "[parser]") {
 
     REQUIRE(expect->equals(result));
 }
+
+TEST_CASE("parser_plus_left_associative", "[parser]") {
+    token_stream tokenStream{
+            {token_type ::INTEGER, "1"},
+            {token_type ::PLUS, "+"},
+            {token_type ::INTEGER, "2"},
+            {token_type ::PLUS, "+"},
+            {token_type ::INTEGER, "3"},
+            {token_type ::EOL}};
+
+    decaf::Parser parser{tokenStream};
+    parser.parse();
+
+    auto result = parser.get_ast();
+    auto expect = make_shared<ast::ArithmeticBinary>(
+            make_shared<ast::ArithmeticBinary>(
+                    make_shared<ast::IntConstant>(1),
+                    ast::ArithmeticBinary::Operation::PLUS,
+                    make_shared<ast::IntConstant>(2)),
+            ast::ArithmeticBinary::Operation::PLUS,
+            make_shared<ast::IntConstant>(3));
+
+    REQUIRE(expect->equals(result));
+}
+
+TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
+    token_stream tokenStream{
+            {token_type ::INTEGER, "1"},
+            {token_type ::PLUS, "+"},
+            {token_type ::INTEGER, "2"},
+            {token_type ::STAR, "*"},
+            {token_type ::INTEGER, "3"},
+            {token_type ::EOL}};
+
+    decaf::Parser parser{tokenStream};
+    parser.parse();
+
+    auto result = parser.get_ast();
+    auto expect = make_shared<ast::ArithmeticBinary>(
+            make_shared<ast::IntConstant>(1),
+            ast::ArithmeticBinary::Operation::PLUS,
+            make_shared<ast::ArithmeticBinary>(
+                    make_shared<ast::IntConstant>(2),
+                    ast::ArithmeticBinary::Operation::MULTIPLY,
+                    make_shared<ast::IntConstant>(3)));
+
+    REQUIRE(expect->equals(result));
+}

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -16,10 +16,10 @@ TEST_CASE("parser_main", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = make_shared<ast::ArithmeticBinary>(
-            make_shared<ast::IntConstant>(12),
+    auto expect = new ast::ArithmeticBinary(
+            new ast::IntConstant(12),
             ast::ArithmeticBinary::Operation::PLUS,
-            make_shared<ast::IntConstant>(34));
+            new ast::IntConstant(34));
 
     REQUIRE(expect->equals(result));
 }
@@ -37,13 +37,13 @@ TEST_CASE("parser_plus_left_associative", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = make_shared<ast::ArithmeticBinary>(
-            make_shared<ast::ArithmeticBinary>(
-                    make_shared<ast::IntConstant>(1),
+    auto expect = new ast::ArithmeticBinary(
+            new ast::ArithmeticBinary(
+                    new ast::IntConstant(1),
                     ast::ArithmeticBinary::Operation::PLUS,
-                    make_shared<ast::IntConstant>(2)),
+                    new ast::IntConstant(2)),
             ast::ArithmeticBinary::Operation::PLUS,
-            make_shared<ast::IntConstant>(3));
+            new ast::IntConstant(3));
 
     REQUIRE(expect->equals(result));
 }
@@ -61,13 +61,13 @@ TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = make_shared<ast::ArithmeticBinary>(
-            make_shared<ast::IntConstant>(1),
+    auto expect = new ast::ArithmeticBinary(
+            new ast::IntConstant(1),
             ast::ArithmeticBinary::Operation::PLUS,
-            make_shared<ast::ArithmeticBinary>(
-                    make_shared<ast::IntConstant>(2),
+            new ast::ArithmeticBinary(
+                    new ast::IntConstant(2),
                     ast::ArithmeticBinary::Operation::MULTIPLY,
-                    make_shared<ast::IntConstant>(3)));
+                    new ast::IntConstant(3)));
 
     REQUIRE(expect->equals(result));
 }

--- a/tests/simple_driver.cpp
+++ b/tests/simple_driver.cpp
@@ -1,10 +1,5 @@
-#include "parser_impl.h"
 #include <iostream>
 #include <vector>
 using namespace std;
 int main() {
-    // yy::parser parser;
-    // parser.parse();
-    // auto tok = yylex();
-    // cout << tok << endl;
 }

--- a/token/CMakeLists.txt
+++ b/token/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(token token.cpp)
 target_include_directories(token PUBLIC .)
+target_link_libraries(token PUBLIC parser_impl_basic)
 add_dependencies(token run_flex_bison)


### PR DESCRIPTION
目前`decaf::Parser`类暂时不能实例化，无法指定输入。

全局函数`yylex`已经定义完成。

由于`parser_impl.h`的广泛依赖性，将其单独独立成一个Header-Only的目标。