### PR TITLE
AST节点IntConstant继承出错

### DIFF
--- a/ast/expr.h
+++ b/ast/expr.h
@@ -52,7 +52,7 @@ struct ArithmeticBinary: public Expr {
     bool equals(Expr* ptr) override;
 };
 
-struct IntConstant: Expr, public std::enable_shared_from_this<IntConstant> {
+struct IntConstant: Expr {
     int value;
 
     explicit IntConstant(int val):


### PR DESCRIPTION
IntConstant继承了不应该继承的`enable_shared_from_this`。是在 #20 中遗漏的更改，现在补上