### PR TITLE
修复单元测试名称错误

### DIFF
--- a/tests/compiler/compiler_test.cpp
+++ b/tests/compiler/compiler_test.cpp
@@ -120,7 +120,7 @@ TEST_CASE("compiler_plus_minus", "[compiler]") {
     delete input_ast;
 }
 
-TEST_CASE("parser_multiply_divide", "[parser]") {
+TEST_CASE("compiler_multiply_divide", "[compiler]") {
     using namespace decaf;
     auto input_ast = new ast::ArithmeticBinary(
             new ast::ArithmeticBinary(


### PR DESCRIPTION
构造单元测试`"compiler_multiply_divide", "[compiler]"`时，名称出错了。导致测试冲突，现修复。

感谢 @mask717 指正