### PR TITLE
使用智能指针存储AST语法树

### DIFF
--- a/ast/expr.cpp
+++ b/ast/expr.cpp
@@ -7,8 +7,8 @@ const std::map<decaf::ast::ArithmeticBinary::Operation, std::string> decaf::ast:
     {Operation::DIVIDE, "DIVIDE"},
     {Operation::MOD, "MOD"}};
 
-bool decaf::ast::ArithmeticBinary::equals(Expr* ptr) {
-    auto arith = dynamic_cast<ArithmeticBinary*>(ptr);
+bool decaf::ast::ArithmeticBinary::equals(std::shared_ptr<Expr> ptr) {
+    auto arith = std::dynamic_pointer_cast<ArithmeticBinary>(ptr);
 
     // Not the same type
     if (arith == nullptr) {
@@ -27,8 +27,8 @@ boost::json::value decaf::ast::ArithmeticBinary::to_json() {
     return result;
 }
 
-bool decaf::ast::IntConstant::equals(Expr* ptr) {
-    auto val = dynamic_cast<IntConstant*>(ptr);
+bool decaf::ast::IntConstant::equals(std::shared_ptr<Expr> ptr) {
+    auto val = std::dynamic_pointer_cast<IntConstant>(ptr);
 
     if (val == nullptr) {
         return false;
@@ -44,8 +44,8 @@ boost::json::value decaf::ast::IntConstant::to_json() {
     return result;
 }
 
-bool decaf::ast::Group::equals(decaf::ast::Expr* ptr) {
-    auto group = dynamic_cast<Group*>(ptr);
+bool decaf::ast::Group::equals(std::shared_ptr<Expr> ptr) {
+    auto group = std::dynamic_pointer_cast<Group>(ptr);
 
     if (group == nullptr) {
         return false;

--- a/cli/decaf.cpp
+++ b/cli/decaf.cpp
@@ -24,7 +24,6 @@ void run_repl() {
         decaf::Compiler compiler{ast_root};
         compiler.compile();
         auto program = compiler.get_program();
-        delete ast_root;
 
         decaf::VirtualMachine vm{program};
         vm.run();

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <unordered_map>
 
-std::any decaf::Compiler::visitArithmeticBinary(decaf::ast::ArithmeticBinary* binary) {
+std::any decaf::Compiler::visitArithmeticBinary(std::shared_ptr<decaf::ast::ArithmeticBinary> binary) {
     // Push lhs and rhs first into the stack
     binary->left->accept(*this);
     binary->right->accept(*this);
@@ -24,7 +24,7 @@ std::any decaf::Compiler::visitArithmeticBinary(decaf::ast::ArithmeticBinary* bi
     return {};
 }
 
-std::any decaf::Compiler::visitIntConstant(decaf::ast::IntConstant* constant) {
+std::any decaf::Compiler::visitIntConstant(std::shared_ptr<decaf::ast::IntConstant> constant) {
     if (constant->value > UINT8_MAX) {
         IntConstantPool::index_type index = prog.add_int_constant(constant->value);
         prog.emit_bytes(
@@ -38,7 +38,7 @@ std::any decaf::Compiler::visitIntConstant(decaf::ast::IntConstant* constant) {
     return {};
 }
 
-std::any decaf::Compiler::visitGroup(ast::Group* group) {
+std::any decaf::Compiler::visitGroup(std::shared_ptr<ast::Group> group) {
     group->content->accept(*this);
     return {};
 }

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "byte_code.h"
 #include "expr.h"
 #include "program.h"
@@ -10,19 +12,19 @@ class Compiler:
     public ExprVisitor {
 public:
     // Compiler doesn't own the root
-    explicit Compiler(ast::Expr* root):
-        ast_root{root} {
+    explicit Compiler(std::shared_ptr<ast::Expr> root):
+        ast_root{std::move(root)} {
     }
 
     void compile();
     Program get_program();
 
-    std::any visitArithmeticBinary(ast::ArithmeticBinary* binary) override;
-    std::any visitIntConstant(ast::IntConstant* constant) override;
-    std::any visitGroup(ast::Group* group) override;
+    std::any visitArithmeticBinary(std::shared_ptr<ast::ArithmeticBinary> binary) override;
+    std::any visitIntConstant(std::shared_ptr<ast::IntConstant> constant) override;
+    std::any visitGroup(std::shared_ptr<ast::Group> group) override;
 
 private:
-    ast::Expr* ast_root;
+    std::shared_ptr<ast::Expr> ast_root;
     Program prog{};
 };
 

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -13,7 +13,7 @@ class Parser {
     friend class yy::parser;
 
 public:
-    using ast_ptr = decaf::ast::Expr*;
+    using ast_ptr = std::shared_ptr<ast::Expr>;
     void parse();
     ast_ptr get_ast();
 

--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -19,10 +19,10 @@
     using namespace decaf::ast;
 }
 
-%nterm <decaf::ast::Expr*> expression
-%nterm <decaf::ast::Expr*> arithmeticBinaryExpr
-%nterm <decaf::ast::Expr*> intConstant
-%nterm <decaf::ast::Expr*> group
+%nterm <std::shared_ptr<decaf::ast::Expr>> expression
+%nterm <std::shared_ptr<decaf::ast::Expr>> arithmeticBinaryExpr
+%nterm <std::shared_ptr<decaf::ast::Expr>> intConstant
+%nterm <std::shared_ptr<decaf::ast::Expr>> group
 
 %token <int> INTEGER
 %token <int> HEX_INTEGER
@@ -52,35 +52,35 @@ expression:
 
 arithmeticBinaryExpr: 
     expression PLUS expression {
-        $$ = new ArithmeticBinary (
+        $$ = std::make_shared<ArithmeticBinary>(
             $1,
             ArithmeticBinary::Operation::PLUS,
             $3
         );
     }
     | expression MINUS expression {
-        $$ = new ArithmeticBinary (
+        $$ = std::make_shared<ArithmeticBinary>(
             $1,
             ArithmeticBinary::Operation::MINUS,
             $3
         );
     }
     | expression STAR expression {
-        $$ = new ArithmeticBinary (
+        $$ = std::make_shared<ArithmeticBinary>(
             $1,
             ArithmeticBinary::Operation::MULTIPLY,
             $3
         );
     }
     | expression SLASH expression {
-        $$ = new ArithmeticBinary (
+        $$ = std::make_shared<ArithmeticBinary>(
             $1,
             ArithmeticBinary::Operation::DIVIDE,
             $3
         );
     }
     | expression PERCENT expression {
-        $$ = new ArithmeticBinary (
+        $$ = std::make_shared<ArithmeticBinary>(
             $1,
             ArithmeticBinary::Operation::MOD,
             $3
@@ -89,17 +89,17 @@ arithmeticBinaryExpr:
 
 group:
     LEFT_PAREN expression RIGHT_PAREN {
-        $$ = new Group {
+        $$ = std::make_shared<Group>(
             $2
-        };
+        );
     }
 
 intConstant:
     INTEGER {
-        $$ = new IntConstant($1);
+        $$ = std::make_shared<IntConstant>($1);
     } |
     HEX_INTEGER {
-        $$ = new IntConstant($1);
+        $$ = std::make_shared<IntConstant>($1);
     }
 
 %%

--- a/tests/ast/ast_test.cpp
+++ b/tests/ast/ast_test.cpp
@@ -3,7 +3,7 @@
 using namespace decaf;
 
 TEST_CASE("intconstant_json", "[ast]") {
-    auto ast_root = new ast::IntConstant(3);
+    auto ast_root = std::make_shared<ast::IntConstant>(3);
     boost::json::value expect_json = boost::json::parse(R"(
 {
     "type": "IntConstant",
@@ -11,17 +11,16 @@ TEST_CASE("intconstant_json", "[ast]") {
 }
 )");
     REQUIRE(expect_json == ast_root->to_json());
-    delete ast_root;
 }
 
 TEST_CASE("arithmetic_binary_json", "[ast]") {
-    auto ast_root = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto ast_root = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::MULTIPLY,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::DIVIDE,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
     boost::json::value expect_json = boost::json::parse(R"(
 {
     "type": "ArithmeticBinary",
@@ -45,5 +44,4 @@ TEST_CASE("arithmetic_binary_json", "[ast]") {
 }
 )");
     REQUIRE(expect_json == ast_root->to_json());
-    delete ast_root;
 }

--- a/tests/compiler/compiler_test.cpp
+++ b/tests/compiler/compiler_test.cpp
@@ -4,10 +4,10 @@
 
 TEST_CASE("compiler_main", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary{
-        new ast::IntConstant{1},
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::IntConstant>(1),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::IntConstant{2}};
+        std::make_shared<ast::IntConstant>(2));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -24,18 +24,17 @@ TEST_CASE("compiler_main", "[compiler]") {
         }};
 
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_plus_deep", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::PLUS,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -55,18 +54,17 @@ TEST_CASE("compiler_plus_deep", "[compiler]") {
         }};
 
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_plus_multiply", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary(
-        new ast::IntConstant(1),
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::IntConstant>(1),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(2),
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(2),
             ast::ArithmeticBinary::Operation::MULTIPLY,
-            new ast::IntConstant(3)));
+            std::make_shared<ast::IntConstant>(3)));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -86,18 +84,17 @@ TEST_CASE("compiler_plus_multiply", "[compiler]") {
         }};
 
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_plus_minus", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::PLUS,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::MINUS,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -117,18 +114,17 @@ TEST_CASE("compiler_plus_minus", "[compiler]") {
         }};
 
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_multiply_divide", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::MULTIPLY,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::DIVIDE,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -148,16 +144,14 @@ TEST_CASE("compiler_multiply_divide", "[compiler]") {
         }};
 
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_mod", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary{
-        new ast::IntConstant(15),
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::IntConstant>(15),
         ast::ArithmeticBinary::Operation::MOD,
-        new ast::IntConstant(7),
-    };
+        std::make_shared<ast::IntConstant>(7));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -173,15 +167,14 @@ TEST_CASE("compiler_mod", "[compiler]") {
             Instruction ::MOD,
         }};
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_int_constant_pool", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::ArithmeticBinary(
-        new ast::IntConstant(10000),
+    auto input_ast = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::IntConstant>(10000),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::IntConstant(2345));
+        std::make_shared<ast::IntConstant>(2345));
     decaf::Compiler compiler{input_ast};
     compiler.compile();
 
@@ -200,13 +193,12 @@ TEST_CASE("compiler_int_constant_pool", "[compiler]") {
             2345,
         }};
     REQUIRE(expect == result);
-    delete input_ast;
 }
 
 TEST_CASE("compiler_group", "[compiler]") {
     using namespace decaf;
-    auto input_ast = new ast::Group{
-        new ast::IntConstant(1)};
+    auto input_ast = std::make_shared<ast::Group>(
+        std::make_shared<ast::IntConstant>(1));
 
     decaf::Compiler compiler{input_ast};
     compiler.compile();
@@ -219,5 +211,4 @@ TEST_CASE("compiler_group", "[compiler]") {
             1,
         }};
     REQUIRE(expect == result);
-    delete input_ast;
 }

--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -16,14 +16,12 @@ TEST_CASE("parser_main", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = new ast::ArithmeticBinary(
-        new ast::IntConstant(12),
+    auto expect = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::IntConstant>(12),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::IntConstant(34));
+        std::make_shared<ast::IntConstant>(34));
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }
 
 TEST_CASE("parser_plus_left_associative", "[parser]") {
@@ -39,17 +37,15 @@ TEST_CASE("parser_plus_left_associative", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto expect = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::PLUS,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }
 
 TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
@@ -65,17 +61,15 @@ TEST_CASE("parser_plus_multiply_precedence", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = new ast::ArithmeticBinary(
-        new ast::IntConstant(1),
+    auto expect = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::IntConstant>(1),
         ast::ArithmeticBinary::Operation::PLUS,
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(2),
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(2),
             ast::ArithmeticBinary::Operation::MULTIPLY,
-            new ast::IntConstant(3)));
+            std::make_shared<ast::IntConstant>(3)));
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }
 
 TEST_CASE("parser_plus_minus", "[parser]") {
@@ -91,17 +85,15 @@ TEST_CASE("parser_plus_minus", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto expect = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::PLUS,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::MINUS,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }
 
 TEST_CASE("parser_multiply_divide", "[parser]") {
@@ -117,17 +109,15 @@ TEST_CASE("parser_multiply_divide", "[parser]") {
     parser.parse();
 
     auto result = parser.get_ast();
-    auto expect = new ast::ArithmeticBinary(
-        new ast::ArithmeticBinary(
-            new ast::IntConstant(1),
+    auto expect = std::make_shared<ast::ArithmeticBinary>(
+        std::make_shared<ast::ArithmeticBinary>(
+            std::make_shared<ast::IntConstant>(1),
             ast::ArithmeticBinary::Operation::MULTIPLY,
-            new ast::IntConstant(2)),
+            std::make_shared<ast::IntConstant>(2)),
         ast::ArithmeticBinary::Operation::DIVIDE,
-        new ast::IntConstant(3));
+        std::make_shared<ast::IntConstant>(3));
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }
 
 TEST_CASE("parser_mod", "[parser]") {
@@ -142,14 +132,12 @@ TEST_CASE("parser_mod", "[parser]") {
 
     auto result = parser.get_ast();
     auto expect = new ast::ArithmeticBinary{
-        new ast::IntConstant(15),
+        std::make_shared<ast::IntConstant>(15),
         ast::ArithmeticBinary::Operation::MOD,
-        new ast::IntConstant(7),
+        std::make_shared<ast::IntConstant>(7),
     };
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }
 
 TEST_CASE("parser_group", "[parser]") {
@@ -164,9 +152,7 @@ TEST_CASE("parser_group", "[parser]") {
 
     auto result = parser.get_ast();
     auto expect = new ast::Group{
-        new ast::IntConstant(1)};
+        std::make_shared<ast::IntConstant>(1)};
 
     REQUIRE(expect->equals(result));
-    delete result;
-    delete expect;
 }

--- a/tests/simple_driver.cpp
+++ b/tests/simple_driver.cpp
@@ -6,22 +6,4 @@
 #include <vector>
 using namespace std;
 int main() {
-    auto ast_root = new decaf::ast::ArithmeticBinary(
-        new decaf::ast::ArithmeticBinary(
-            new decaf::ast::IntConstant(1),
-            decaf::ast::ArithmeticBinary::Operation::MULTIPLY,
-            new decaf::ast::IntConstant(2)),
-        decaf::ast::ArithmeticBinary::Operation::DIVIDE,
-        new decaf::ast::IntConstant(3));
-    cout << serialize(ast_root->to_json()) << endl;
-    delete ast_root;
-    decaf::token_stream tokens = {
-        {decaf::token_type ::PLUS, "+"},
-        {decaf::token_type ::MINUS, "-"},
-        {decaf::token_type ::STAR, "*"},
-        {decaf::token_type ::SLASH, "/"}};
-
-    auto result = tokens.to_json();
-    auto result_str = serialize(result);
-    cout << result_str << endl;
 }


### PR DESCRIPTION
# 目标

- 使用智能指针存储AST语法树

这样可以确保在Parser丢弃token时，对应的语义值能得到释放。