### PR TITLE
合并常量池类型

### DIFF
--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -26,7 +26,7 @@ std::any decaf::Compiler::visitArithmeticBinary(std::shared_ptr<decaf::ast::Arit
 
 std::any decaf::Compiler::visitIntConstant(std::shared_ptr<decaf::ast::IntConstant> constant) {
     if (constant->value > UINT8_MAX) {
-        IntConstantPool::index_type index = prog.add_int_constant(constant->value);
+        ConstantPool::index_type index = prog.add_int_constant(constant->value);
         prog.emit_bytes(
             ByteCode::Instruction::GET_INT_CONSTANT,
             index);

--- a/program/constant_pool.cpp
+++ b/program/constant_pool.cpp
@@ -1,7 +1,7 @@
 #include "constant_pool.h"
 
 
-decaf::IntConstantPool::index_type decaf::IntConstantPool::add_constant(const int& val) {
+decaf::ConstantPool::index_type decaf::ConstantPool::add_constant(const int& val) {
     // TODO: O(n) here, however there's not so many constant at all
     // Efficiency doesn't matter
     for (index_type i = 0; i < pool.size(); i++) {
@@ -14,12 +14,12 @@ decaf::IntConstantPool::index_type decaf::IntConstantPool::add_constant(const in
     return pool.size() - 1;
 }
 
-int decaf::IntConstantPool::get_constant(decaf::IntConstantPool::index_type index) {
+int decaf::ConstantPool::get_int_constant(index_type index) {
     return pool[index];
 }
 
-std::ostream& operator<<(std::ostream& os, const decaf::IntConstantPool& i_pool) {
-    for (decaf::IntConstantPool::index_type i = 0; i < i_pool.pool.size(); i++) {
+std::ostream& operator<<(std::ostream& os, const decaf::ConstantPool& i_pool) {
+    for (decaf::ConstantPool::index_type i = 0; i < i_pool.pool.size(); i++) {
         os << "[" << i << "] = " << i_pool.pool[i] << ',';
     }
     return os;

--- a/program/constant_pool.h
+++ b/program/constant_pool.h
@@ -5,35 +5,27 @@
 #include <vector>
 
 namespace decaf {
-class IntConstantPool;
+class ConstantPool;
 }
 
-std::ostream& operator<<(std::ostream& os, const decaf::IntConstantPool&);
+std::ostream& operator<<(std::ostream& os, const decaf::ConstantPool&);
 
 namespace decaf {
 
-template<typename T>
-class BasicConstantPool {
+class ConstantPool {
+    friend std::ostream& ::operator<<(std::ostream& os, const decaf::ConstantPool&);
+
 public:
     using index_type = size_t;
-    virtual index_type add_constant(const T&) = 0;
-    virtual T get_constant(index_type) = 0;
-};
-
-class IntConstantPool:
-    public BasicConstantPool<int> {
-    friend std::ostream& ::operator<<(std::ostream& os, const decaf::IntConstantPool&);
-
-public:
-    IntConstantPool() = default;
-    IntConstantPool(std::initializer_list<int> list):
+    ConstantPool() = default;
+    ConstantPool(std::initializer_list<int> list):
         pool(list) {
     }
 
-    index_type add_constant(const int& val) override;
-    int get_constant(index_type index) override;
+    index_type add_constant(const int& val);
+    int get_int_constant(index_type index);
 
-    bool operator==(const IntConstantPool& rhs) {
+    bool operator==(const ConstantPool& rhs) {
         return pool == rhs.pool;
     }
 

--- a/program/program.cpp
+++ b/program/program.cpp
@@ -2,12 +2,12 @@
 
 std::ostream& operator<<(std::ostream& os, const decaf::Program& prog) {
     os << "{ code = 0x{" << prog.code << "}\n";
-    os << "  Int Constant = [" << prog.i_pool << "] }";
+    os << "  Int Constant = [" << prog.pool << "] }";
     return os;
 }
 
-decaf::IntConstantPool::index_type decaf::Program::add_int_constant(const int& val) {
-    return i_pool.add_constant(val);
+decaf::ConstantPool::index_type decaf::Program::add_int_constant(const int& val) {
+    return pool.add_constant(val);
 }
 
 void decaf::Program::set_result_type(const decaf::Type& result) {

--- a/program/program.h
+++ b/program/program.h
@@ -24,8 +24,8 @@ public:
     explicit Program(ByteCode _code):
         Program(std::move(_code), {}) {
     }
-    Program(ByteCode _code, IntConstantPool _i_pool):
-        code{std::move(_code)}, i_pool{std::move(_i_pool)} {
+    Program(ByteCode _code, ConstantPool _pool):
+        code{std::move(_code)}, pool{std::move(_pool)} {
     }
 
     void emit(ByteCode::code_type b) {
@@ -38,19 +38,19 @@ public:
         code.emit(b2);
     }
 
-    IntConstantPool::index_type add_int_constant(const int& val);
+    ConstantPool::index_type add_int_constant(const int& val);
 
     void set_result_type(const Type& result);
     void set_result_type_classification(const Type::Classification& classification);
 
     bool operator==(const Program& rhs) {
-        return this->code == rhs.code && this->i_pool == rhs.i_pool;
+        return this->code == rhs.code && this->pool == rhs.pool;
     }
 
 private:
     ByteCode code;
     Type result_type;
-    IntConstantPool i_pool;
+    ConstantPool pool;
 };
 
 } // namespace decaf

--- a/tests/compiler/compiler_test.cpp
+++ b/tests/compiler/compiler_test.cpp
@@ -188,7 +188,7 @@ TEST_CASE("compiler_int_constant_pool", "[compiler]") {
             1,
             Instruction ::PLUS,
         },
-        IntConstantPool{
+        ConstantPool{
             10000,
             2345,
         }};

--- a/vm/vm.cpp
+++ b/vm/vm.cpp
@@ -46,7 +46,7 @@ void decaf::VirtualMachine::op_GET_INSTANT(uint8_t instant) {
 }
 
 void decaf::VirtualMachine::op_GET_INT_CONSTANT(uint8_t index) {
-    stk.emplace(prog.i_pool.get_constant(index));
+    stk.emplace(prog.pool.get_int_constant(index));
 }
 
 


### PR DESCRIPTION
考虑到C++中，不能按照返回值重载函数，基类里的`get_constant`根本没用。

```cpp
template<typename T>
class BasicConstantPool {
public:
    using index_type = size_t;
    virtual index_type add_constant(const T&) = 0;
    virtual T get_constant(index_type) = 0;
};
```

就把这一整段都删除了吧