### PR TITLE
补充要求：scanner单元测试必须无错误

### DIFF
--- a/tests/scanner/scanner_test.cpp
+++ b/tests/scanner/scanner_test.cpp
@@ -8,6 +8,7 @@ decaf::token_stream scan_for(const std::string& str) {
     std::istringstream input{str};
     decaf::Scanner scanner{input};
     scanner.scan();
+    REQUIRE(!scanner.is_error());
     return scanner.get_tokens();
 }
 


### PR DESCRIPTION
这是scanner安全的体现之一，现在加入单元测试中。