### PR TITLE
添加程序获取结果类型接口

### DIFF
--- a/program/program.cpp
+++ b/program/program.cpp
@@ -17,3 +17,11 @@ void decaf::Program::set_result_type(const decaf::Type& result) {
 void decaf::Program::set_result_type_classification(const decaf::Type::Classification& classification) {
     result_type.classification = classification;
 }
+
+decaf::Type decaf::Program::get_result_type() const {
+    return result_type;
+}
+
+decaf::Type::Classification decaf::Program::get_result_type_classification() const {
+    return result_type.classification;
+}

--- a/program/program.h
+++ b/program/program.h
@@ -40,6 +40,8 @@ public:
 
     IntConstantPool::index_type add_int_constant(const int& val);
 
+    [[nodiscard]] Type get_result_type() const;
+    [[nodiscard]] Type::Classification get_result_type_classification() const;
     void set_result_type(const Type& result);
     void set_result_type_classification(const Type::Classification& classification);
 

--- a/tests/compiler/compiler_test.cpp
+++ b/tests/compiler/compiler_test.cpp
@@ -14,6 +14,7 @@ TEST_CASE("compiler_main", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,
@@ -41,6 +42,7 @@ TEST_CASE("compiler_plus_deep", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,
@@ -71,6 +73,7 @@ TEST_CASE("compiler_plus_multiply", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,
@@ -101,6 +104,7 @@ TEST_CASE("compiler_plus_minus", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,
@@ -131,6 +135,7 @@ TEST_CASE("compiler_multiply_divide", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,
@@ -158,6 +163,7 @@ TEST_CASE("compiler_mod", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,
@@ -180,6 +186,7 @@ TEST_CASE("compiler_int_constant_pool", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INT_CONSTANT,
@@ -205,6 +212,7 @@ TEST_CASE("compiler_group", "[compiler]") {
 
     using Instruction = ByteCode::Instruction;
     auto result = compiler.get_program();
+    REQUIRE(result.get_result_type_classification() == Type::Classification::INT);
     auto expect = Program{
         ByteCode{
             Instruction ::GET_INSTANT,


### PR DESCRIPTION
# 原因

让外部能获取生成程序的结果类型，就能让单元测试中测试程序的返回值是否正确。