### PR TITLE
为Bool类型添加Parser单元测试类型要求

### DIFF
--- a/tests/parser/parser_test.cpp
+++ b/tests/parser/parser_test.cpp
@@ -197,6 +197,7 @@ TEST_CASE("parser_and", "[parser]") {
     REQUIRE(!parser.is_error());
 
     auto result = parser.get_ast();
+    REQUIRE(result->type.classification == Type::Classification::BOOL);
     auto expect = std::make_shared<ast::LogicBinary>(
         std::make_shared<ast::BoolConstant>(true),
         ast::LogicBinary::Operation::LOGIC_AND,
@@ -219,6 +220,7 @@ TEST_CASE("parser_or", "[parser]") {
     REQUIRE(!parser.is_error());
 
     auto result = parser.get_ast();
+    REQUIRE(result->type.classification == Type::Classification::BOOL);
     auto expect = std::make_shared<ast::LogicBinary>(
         std::make_shared<ast::BoolConstant>(true),
         ast::LogicBinary::Operation::LOGIC_OR,
@@ -242,6 +244,7 @@ TEST_CASE("parser_logic_binary_combined_precedence", "[parser]") {
     REQUIRE(!parser.is_error());
 
     auto result = parser.get_ast();
+    REQUIRE(result->type.classification == Type::Classification::BOOL);
     auto expect = std::make_shared<ast::LogicBinary>(
         std::make_shared<ast::BoolConstant>(true),
         ast::LogicBinary::Operation::LOGIC_OR,


### PR DESCRIPTION
# 原因

同 #52 ，对单元测试要求的补充