### PR TITLE
添加ByteCodeDriver汇报错误接口

### DIFF
--- a/byte_code/byte_code_driver.cpp
+++ b/byte_code/byte_code_driver.cpp
@@ -1,12 +1,13 @@
 #include "byte_code_driver.h"
 
-void decaf::ByteCodeDriver::produce() {
+bool decaf::ByteCodeDriver::produce() {
     while (current_byte != code_stream.end()) {
         bool success = produce_instruction();
         if (!success)
-            break;
+            return false;
         current_byte++;
     }
+    return true;
 }
 
 // Contract

--- a/byte_code/byte_code_driver.h
+++ b/byte_code/byte_code_driver.h
@@ -9,7 +9,7 @@ public:
         code{code}, visitor{visitor} {
     }
 
-    virtual void produce();
+    virtual bool produce();
     using code_stream_type = ByteCode::code_stream_type;
     using iterator_type = code_stream_type::iterator;
 


### PR DESCRIPTION
# 原因

既然单步可以汇报错误，那多步执行的错误也不应该丢弃。

有助于VM单元测试