### PR TITLE
启用LAC生成更详细的语法错误

### DIFF
--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -3,6 +3,7 @@
 /* %define api.token.constructor */
 %define parse.error verbose
 %define parse.trace
+%define parse.lac full
 
 %param{decaf::Parser& driver}
 


### PR DESCRIPTION
功能详见bison文档的[这一小节](https://www.gnu.org/software/bison/manual/bison.html#LAC)