### PR TITLE
改用更强大的IELR文法

### DIFF
--- a/parser/parser_impl.yy
+++ b/parser/parser_impl.yy
@@ -2,6 +2,7 @@
 %define api.value.type variant
 /* %define api.token.constructor */
 %define parse.error verbose
+%define lr.type ielr
 %define parse.trace
 
 %param{decaf::Parser& driver}


### PR DESCRIPTION
详见bison文档的[这一小节](https://www.gnu.org/software/bison/manual/bison.html#LR-Table-Construction)

默认文法为LALR(1)，但是我相信我们都不符合适合LALR(1)的两大场景：

> GLR without static conflict resolution.
> Malformed grammars.

希望这有助于我们日后开发语句